### PR TITLE
Improve get software versions

### DIFF
--- a/madatv_get_device_infos.json
+++ b/madatv_get_device_infos.json
@@ -1,5 +1,5 @@
 {
-  "ATV - Readout hardware infos": [
+  "ATV - Get device infos": [
     {
       "TYPE": "jobType.PASSTHROUGH",
       "SYNTAX": "echo \"CPU $( (grep -q '^Hardware' /proc/cpuinfo && grep '^Processor' /proc/cpuinfo || grep '^model name' /proc/cpuinfo) | head -n1 | sed -r -e 's/.*: *//' -e 's/(processor *|cpu)//gi' -e 's/ *\\(.*//g') | RAM $(awk '/MemTotal/{printf \"%1.0f\", $2 / 1000000}' /proc/meminfo) GB | ABI $(getprop ro.product.cpu.abi) | IP $(awk '/32 host/ {print f} {f=$2}' /proc/net/fib_trie | grep -v 127.0.0.1) | Pingreboot $([ -f /sdcard/pingreboot ] && echo enabled || echo disabled) | Temperature $(awk '{print substr($0,1,length()-3)}' /sys/class/thermal/thermal_zone0/temp || echo ?)°C\""

--- a/madatv_get_software_versions.json
+++ b/madatv_get_software_versions.json
@@ -2,7 +2,7 @@
   "ATV - Get software versions": [
     {
       "TYPE": "jobType.PASSTHROUGH",
-      "SYNTAX": "echo \"RGC $(dumpsys package de.grennith.rgc.remotegpscontroller | grep versionName | head -n1 | sed 's/ *versionName=//') | PD $(dumpsys package com.mad.pogodroid | grep versionName | head -n1 | sed 's/ *versionName=//') | PoGo $(dumpsys package com.nianticlabs.pokemongo | grep versionName | head -n1 | sed 's/ *versionName=//') | Magisk $(magisk -c | sed 's/:.*//') $(ls -1 /sbin/.magisk/img 2>/dev/null) | ROM $(cat /sdcard/madversion 2>/dev/null || echo unknown)\"",
+      "SYNTAX": "echo \"RGC $(dumpsys package de.grennith.rgc.remotegpscontroller | grep versionName | head -n1 | sed 's/ *versionName=//') | PD $(dumpsys package com.mad.pogodroid | grep versionName | head -n1 | sed 's/ *versionName=//') | PoGo $(dumpsys package com.nianticlabs.pokemongo | grep versionName | head -n1 | sed 's/ *versionName=//') | Autoupdate $([ -f /sdcard/disableautopogoupdate ] && echo enabled || echo disabled) | Magisk $(magisk -c | sed 's/:.*//') $(ls -1 /sbin/.magisk/img 2>/dev/null) | ROM $(cat /sdcard/madversion 2>/dev/null || echo unknown)\"",
       "FIELDNAME": "Versions"
     }
   ]

--- a/madatv_get_software_versions.json
+++ b/madatv_get_software_versions.json
@@ -2,7 +2,7 @@
   "ATV - Get software versions": [
     {
       "TYPE": "jobType.PASSTHROUGH",
-      "SYNTAX": "echo \"RGC $(dumpsys package de.grennith.rgc.remotegpscontroller | grep versionName | head -n1 | sed 's/ *versionName=//') | PD $(dumpsys package com.mad.pogodroid | grep versionName | head -n1 | sed 's/ *versionName=//') | PoGo $(dumpsys package com.nianticlabs.pokemongo | grep versionName | head -n1 | sed 's/ *versionName=//') | Magisk $(magisk -c) | Magisk Modules $(ls /sbin/.magisk/img 2>/dev/null|tr -s ' '|tr '\n' ' ') | ROM $(cat /sdcard/madversion 2>/dev/null || echo unknown)\"",
+      "SYNTAX": "echo \"RGC $(dumpsys package de.grennith.rgc.remotegpscontroller | grep versionName | head -n1 | sed 's/ *versionName=//') | PD $(dumpsys package com.mad.pogodroid | grep versionName | head -n1 | sed 's/ *versionName=//') | PoGo $(dumpsys package com.nianticlabs.pokemongo | grep versionName | head -n1 | sed 's/ *versionName=//') | Magisk $(magisk -c | sed 's/:.*//') $(ls -1 /sbin/.magisk/img 2>/dev/null) | ROM $(cat /sdcard/madversion 2>/dev/null || echo unknown)\"",
       "FIELDNAME": "Versions"
     }
   ]

--- a/madatv_smali_status.json
+++ b/madatv_smali_status.json
@@ -1,8 +1,0 @@
-{
-  "ATV - Smali: status": [
-    {
-      "TYPE": "jobType.PASSTHROUGH",
-      "SYNTAX": "echo \"Module $(ls -lL /sbin/.magisk/img | grep -q smali && ls -lL /sbin/.magisk/img | grep smali | awk {'print $8'} || echo Not installed)\""
-    }
-  ]
-}


### PR DESCRIPTION
Picking up https://github.com/Map-A-Droid/MAD-ATV/pull/71

This PR improves the former "Readout ALL versions" job:

* Simplify Magisk version string to the plain numeric version
* Merge Magisk module list into Magisk version field, there's no need to be more verbose.
* Show Pogo auto-update status
* Removed show_smali_status because it's already covered with the Magisk module list