### PR TITLE
Invert logic of ATV - PoGo auto-update status

### DIFF
--- a/madatv_pogo_autoupdate.json
+++ b/madatv_pogo_autoupdate.json
@@ -14,7 +14,7 @@
   "ATV - PoGo auto-update: status": [
     {
       "TYPE": "jobType.PASSTHROUGH",
-      "SYNTAX": "[ -f /sdcard/disableautopogoupdate ] && echo enabled || echo disabled"
+      "SYNTAX": "[ -f /sdcard/disableautopogoupdate ] && echo disabled || echo enabled"
     }
   ]
 }


### PR DESCRIPTION
The check is for a disable file, so if the file exists, the feature is disabled.