### PR TITLE
Get DeviceID (used in MAD Auth Backend)

### DIFF
--- a/get_deviceid.json
+++ b/get_deviceid.json
@@ -1,0 +1,8 @@
+{
+  "Get DeviceID (used in MAD Auth Backend)": [
+    {
+      "TYPE": "jobType.PASSTHROUGH",
+      "SYNTAX": "awk -F'>' '/auth_id/{print $2}' /data/data/com.mad.pogodroid/shared_prefs/com.mad.pogodroid_preferences.xml |  cut -d '<' -f1"
+    }
+  ]
+}


### PR DESCRIPTION
You need to guys decide how do we prefix those "non-only" ATV jobs.
Leaving it blank for now.

This is gonna be useful for new Quest Enhancement mode.